### PR TITLE
Fix socket abnormal closure when duplicate sessions connect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,5 @@ dotnet: 1.0.1
 script:
   - ./build.sh --quiet verify
   - cd Wukong.Tests && dotnet restore && dotnet xunit
-deploy:
-  provider: azure_web_apps
 notifications:
   email: false

--- a/Wukong/Services/Socket.cs
+++ b/Wukong/Services/Socket.cs
@@ -145,7 +145,7 @@ namespace Wukong.Services
             finally
             {
                 logger.LogInformation($"user: {userId} socket disposed.");
-                if (verifiedSocket.TryGetValue(userId, out var currentSocket))
+                if (verifiedSocket.TryGetValue(userId, out var currentSocket) && socket == currentSocket)
                 {
                     // This is the current active socket, remove it.
                     await RemoveSocket(userId);
@@ -162,7 +162,7 @@ namespace Wukong.Services
         private async Task RemoveSocket(string userId)
         {
             userManager.GetUser(userId)?.Disconnect();
-            if (verifiedSocket.TryRemove(userId, out var ws))
+            if (verifiedSocket.TryRemove(userId, out var socket))
             {
                 logger.LogInformation($"remove socket {userId}");
                 await socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "Close",


### PR DESCRIPTION
As mentioned in title, a socket abnormal closure issue was fixed.

Before this, if a user opened the second socket, both socket 1 and socket 2 would be closed, whereas socket 2 would not receive Disconnect Event which is abnormal.

After this fix, only socket 1 will be closed normally with Disconnect Event, and socket 2 will remain opened.

P.S. Disconnect Event and normal closure (1000) code is correctly handled only in WukongAndroid. I will send a PR to WukongClient and Web, to help WukongWeb and WukongiOS add or implement this feature.